### PR TITLE
Add github workflows for syncing with the release repo, & building releases

### DIFF
--- a/.github/workflows/lockdown-release-repo.yml
+++ b/.github/workflows/lockdown-release-repo.yml
@@ -1,0 +1,23 @@
+name: lockdown-release-repo
+on:
+  issues:
+    types: opened
+  pull_request:
+    types: opened
+
+jobs:
+  lockdown:
+    if: ${{ github.repository_owner == 'terraform-provider-cloudfoundry-v3' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/repo-lockdown@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-comment: >
+            Please submit issues at https://github.com/alphagov/terraform-provider-cf,
+            where development takes place. This repository is solely for the purpose of
+            releases.
+          pr-comment: >
+            Please submit pull requests at https://github.com/alphagov/terraform-provider-cf,
+            where development takes place. This repository is solely for the purpose of
+            releases.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    if: ${{ github.repository_owner == 'terraform-provider-cloudfoundry-v3' }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_SECRET_KEY_PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/sync-release-repo.yml
+++ b/.github/workflows/sync-release-repo.yml
@@ -1,0 +1,21 @@
+name: sync-release-repo
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'release-repo-test-*'
+    branches:
+      - master
+jobs:
+  repo-sync:
+    if: ${{ github.repository_owner == 'alphagov' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: repo-sync
+      uses: wei/git-sync@v2
+      with:
+        source_repo: "https://github.com/${{ github.repository }}.git"
+        source_branch: ${{ github.ref }}
+        destination_repo: "git@github.com:terraform-provider-cloudfoundry-v3/terraform-provider-cloudfoundry-v3.git"
+        destination_branch: ${{ github.ref }}
+        ssh_private_key: ${{ secrets.RELEASE_REPO_SSH_PRIVATE_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,17 +45,14 @@ signs:
       # if you are using this is a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--pinentry-mode"
-      - "loopback"
-      - "--passphrase-file=/tmp/pass.txt"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-  #release:
+release:
   # If you want to manually examine the release before its live, uncomment this line:
-#  draft: true
+  draft: true
 changelog:
   skip: true


### PR DESCRIPTION
https://trello.com/c/JcpCa4q6

This creates two github workflows:

 - the first only runs on _this_ fork, and forwards `master` branch and `v*` tag pushes to the release fork
 - the second only runs on the release fork and performs the build/sign/release there. The release is only marked as draft, so completing the release requires someone to log into the other account to mark it as non-draft.