### PR TITLE
de-v3ify the names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ provider "cloudfoundry-v3" {
   password     = var.cf_password
 }
 
-resource "cloudfoundry_v3_app" "basic" {
+resource "cloudfoundry_app" "basic" {
 	provider              = cloudfoundry-v3
 	name                  = "basic-buildpack"
-	space_id              = data.cloudfoundry_v3_space.myspace.id
+	space_id              = data.cloudfoundry_space.myspace.id
 	environment           = {MY_VAR = "1"}
 	instances             = 2
 	memory_in_mb          = 1024
@@ -52,25 +52,25 @@ resource "cloudfoundry_v3_app" "basic" {
 	health_check_endpoint = "/"
 }
 
-resource "cloudfoundry_v3_droplet" "basic" {
+resource "cloudfoundry_droplet" "basic" {
 	provider         = cloudfoundry-v3
-	app_id           = cloudfoundry_v3_app.basic.id
+	app_id           = cloudfoundry_app.basic.id
 	buildpacks       = ["binary_buildpack"]
-	environment      = cloudfoundry_v3_app.basic.environment
-	command          = cloudfoundry_v3_app.basic.command
+	environment      = cloudfoundry_app.basic.environment
+	command          = cloudfoundry_app.basic.command
 	source_code_path = "/path/to/source.zip"
 	source_code_hash = filemd5("/path/to/source.zip")
 	depends_on = [
-		cloudfoundry_v3_service_binding.splunk,
+		cloudfoundry_service_binding.splunk,
 		cloudfoundry_network_policy.basic,
 	]
 }
 
-resource "cloudfoundry_v3_deployment" "basic" {
+resource "cloudfoundry_deployment" "basic" {
 	provider   = cloudfoundry-v3
 	strategy   = "rolling"
-	app_id     = cloudfoundry_v3_app.basic.id
-	droplet_id = cloudfoundry_v3_droplet.basic.id
+	app_id     = cloudfoundry_app.basic.id
+	droplet_id = cloudfoundry_droplet.basic.id
 }
 ```
 

--- a/cloudfoundryv3/data_source_cf_org_test.go
+++ b/cloudfoundryv3/data_source_cf_org_test.go
@@ -13,11 +13,11 @@ import (
 
 func TestAccDataSourceOrg_normal(t *testing.T) {
 
-	ref := "data.cloudfoundry_v3_org.dd"
+	ref := "data.cloudfoundry_org.dd"
 	org := testAccEnv.Organization
 
 	src := `
-		data "cloudfoundry_v3_org" "dd" {
+		data "cloudfoundry_org" "dd" {
 			name = %q
 		}
 	`

--- a/cloudfoundryv3/data_source_cf_space_test.go
+++ b/cloudfoundryv3/data_source_cf_space_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestAccDataSourceSpace_normal(t *testing.T) {
 
-	ref := "data.cloudfoundry_v3_space.default"
+	ref := "data.cloudfoundry_space.default"
 
 	org := testAccEnv.Organization
 	space := testAccEnv.Space
 
 	src := `
-		data "cloudfoundry_v3_space" "default" {
+		data "cloudfoundry_space" "default" {
 			name = %q
 			org_name = %q
 		}

--- a/cloudfoundryv3/provider.go
+++ b/cloudfoundryv3/provider.go
@@ -85,19 +85,19 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"cloudfoundry_v3_domain": dataSourceDomain(),
-			"cloudfoundry_v3_org":    dataSourceOrg(),
-			"cloudfoundry_v3_space":  dataSourceSpace(),
+			"cloudfoundry_domain": dataSourceDomain(),
+			"cloudfoundry_org":    dataSourceOrg(),
+			"cloudfoundry_space":  dataSourceSpace(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudfoundry_v3_route":             resourceRoute(),
-			"cloudfoundry_v3_route_destination": resourceRouteDestination(),
-			"cloudfoundry_v3_app":               resourceApp(),
-			"cloudfoundry_v3_droplet":           resourceDroplet(),
-			"cloudfoundry_v3_deployment":        resourceDeployment(),
-			"cloudfoundry_v3_service_instance":  resourceServiceInstance(),
-			"cloudfoundry_v3_service_binding":   resourceServiceBinding(),
+			"cloudfoundry_route":             resourceRoute(),
+			"cloudfoundry_route_destination": resourceRouteDestination(),
+			"cloudfoundry_app":               resourceApp(),
+			"cloudfoundry_droplet":           resourceDroplet(),
+			"cloudfoundry_deployment":        resourceDeployment(),
+			"cloudfoundry_service_instance":  resourceServiceInstance(),
+			"cloudfoundry_service_binding":   resourceServiceBinding(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/cloudfoundryv3/resource_cf_service_binding_test.go
+++ b/cloudfoundryv3/resource_cf_service_binding_test.go
@@ -14,21 +14,21 @@ func TestAccResServiceBindingWithAsyncPlan(t *testing.T) {
 
 	src := `
 
-		resource "cloudfoundry_v3_app" "bind" {
+		resource "cloudfoundry_app" "bind" {
 			type = "buildpack"
 			name = "foo-with-binding"
 			space_id = %q
 		}
 
-		resource "cloudfoundry_v3_service_instance" "bind" {
+		resource "cloudfoundry_service_instance" "bind" {
 		  name = "bind"
 		  space_id = %q
 		  service_plan_id = %q
 		}
 
-		resource "cloudfoundry_v3_service_binding" "bind" {
-			app_id = cloudfoundry_v3_app.bind.id
-			service_instance_id = cloudfoundry_v3_service_instance.bind.id
+		resource "cloudfoundry_service_binding" "bind" {
+			app_id = cloudfoundry_app.bind.id
+			service_instance_id = cloudfoundry_service_instance.bind.id
 			params = jsonencode({
 				ignored = true
 			})
@@ -36,7 +36,7 @@ func TestAccResServiceBindingWithAsyncPlan(t *testing.T) {
 
 	`
 
-	refFakeAsyncPlan := "cloudfoundry_v3_service_instance.bind"
+	refFakeAsyncPlan := "cloudfoundry_service_instance.bind"
 	resource.Test(t,
 		resource.TestCase{
 			PreCheck:  func() { testAccPreCheck(t) },

--- a/cloudfoundryv3/resource_cf_service_instance_test.go
+++ b/cloudfoundryv3/resource_cf_service_instance_test.go
@@ -16,7 +16,7 @@ func TestAccResServiceInstancesWithAsyncPlan(t *testing.T) {
 	space := testAccEnv.Space
 	servicePlan := testAccEnv.ServicePlan
 
-	refFakeAsyncPlan := "cloudfoundry_v3_service_instance.async"
+	refFakeAsyncPlan := "cloudfoundry_service_instance.async"
 	resource.Test(t,
 		resource.TestCase{
 			PreCheck:  func() { testAccPreCheck(t) },
@@ -29,7 +29,7 @@ func TestAccResServiceInstancesWithAsyncPlan(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: fmt.Sprintf(`
-						resource "cloudfoundry_v3_service_instance" "async" {
+						resource "cloudfoundry_service_instance" "async" {
 						  name = "async"
 						  space_id = "%s"
 						  service_plan_id = "%s"

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -16,14 +16,14 @@ The following example creates an application. The created application is
 stopped and it does not stage or deploy your application source.
 
 To build your application droplet and have it deployed to your application
-see the `cloudfoundry_v3_droplet` and `cloudfoundry_v3_deployment`
+see the `cloudfoundry_droplet` and `cloudfoundry_deployment`
 resources.
 
 ```hcl
-resource "cloudfoundry_v3_app" "basic" {
+resource "cloudfoundry_app" "basic" {
 	provider              = cloudfoundry-v3
 	name                  = "basic-buildpack"
-	space_id              = data.cloudfoundry_v3_space.myspace.id
+	space_id              = data.cloudfoundry_space.myspace.id
 	environment           = {MY_VAR = "1"}
 	instances             = 2
 	memory_in_mb          = 1024

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -1,12 +1,12 @@
 ---
 layout: "cloudfoundry"
-page_title: "Cloud Foundry: cloudfoundry_v3_deployment"
+page_title: "Cloud Foundry: cloudfoundry_deployment"
 sidebar_current: "docs-cf-resource-deployment"
 description: |-
   Provides a Cloud Foundry Deployment resource.
 ---
 
-# cloudfoundry_v3_deployment
+# cloudfoundry_deployment
 
 Provides a Cloud Foundry [application](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html) resource.
 
@@ -15,10 +15,10 @@ Provides a Cloud Foundry [application](https://docs.cloudfoundry.org/devguide/de
 The following example creates an application, stages a droplet and deploys it with the "rolling" (zero downtime) strategy.
 
 ```hcl
-resource "cloudfoundry_v3_app" "basic" {
+resource "cloudfoundry_app" "basic" {
 	provider              = cloudfoundry-v3
 	name                  = "basic-buildpack"
-	space_id              = data.cloudfoundry_v3_space.myspace.id
+	space_id              = data.cloudfoundry_space.myspace.id
 	environment           = {MY_VAR = "1"}
 	instances             = 2
 	memory_in_mb          = 1024
@@ -27,21 +27,21 @@ resource "cloudfoundry_v3_app" "basic" {
 	health_check_endpoint = "/"
 }
 
-resource "cloudfoundry_v3_droplet" "basic" {
+resource "cloudfoundry_droplet" "basic" {
 	provider         = cloudfoundry-v3
-	app_id           = cloudfoundry_v3_app.basic.id
+	app_id           = cloudfoundry_app.basic.id
 	buildpacks       = ["binary_buildpack"]
-	environment      = cloudfoundry_v3_app.basic.environment
-	command          = cloudfoundry_v3_app.basic.command
+	environment      = cloudfoundry_app.basic.environment
+	command          = cloudfoundry_app.basic.command
 	source_code_path = "/path/to/source.zip"
 	source_code_hash = filemd5("/path/to/source.zip")
 }
 
-resource "cloudfoundry_v3_deployment" "basic" {
+resource "cloudfoundry_deployment" "basic" {
 	provider   = cloudfoundry-v3
 	strategy   = "rolling"
-	app_id     = cloudfoundry_v3_app.basic.id
-	droplet_id = cloudfoundry_v3_droplet.basic.id
+	app_id     = cloudfoundry_app.basic.id
+	droplet_id = cloudfoundry_droplet.basic.id
 }
 ```
 

--- a/docs/resources/droplet.md
+++ b/docs/resources/droplet.md
@@ -1,6 +1,6 @@
 ---
 layout: "cloudfoundry"
-page_title: "Cloud Foundry: cloudfoundry_v3_droplet"
+page_title: "Cloud Foundry: cloudfoundry_droplet"
 sidebar_current: "docs-cf-resource-droplet"
 description: |-
   Provides a Cloud Foundry Droplet resource.
@@ -15,10 +15,10 @@ Provides a Cloud Foundry [application](https://docs.cloudfoundry.org/devguide/de
 The following example creates a droplet (package of your built/staged application.
 
 ```hcl
-resource "cloudfoundry_v3_app" "basic" {
+resource "cloudfoundry_app" "basic" {
 	provider              = cloudfoundry-v3
 	name                  = "basic-buildpack"
-	space_id              = data.cloudfoundry_v3_space.myspace.id
+	space_id              = data.cloudfoundry_space.myspace.id
 	environment           = {MY_VAR = "1"}
 	instances             = 2
 	memory_in_mb          = 1024
@@ -27,12 +27,12 @@ resource "cloudfoundry_v3_app" "basic" {
 	health_check_endpoint = "/"
 }
 
-resource "cloudfoundry_v3_droplet" "basic" {
+resource "cloudfoundry_droplet" "basic" {
 	provider         = cloudfoundry-v3
-	app_id           = cloudfoundry_v3_app.basic.id
+	app_id           = cloudfoundry_app.basic.id
 	buildpacks       = ["binary_buildpack"]
-	environment      = cloudfoundry_v3_app.basic.environment
-	command          = cloudfoundry_v3_app.basic.command
+	environment      = cloudfoundry_app.basic.environment
+	command          = cloudfoundry_app.basic.command
 	source_code_path = "/path/to/source.zip"
 	source_code_hash = filemd5("/path/to/source.zip")
 }
@@ -48,8 +48,8 @@ The following arguments are supported:
    * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag)
    * an installed admin buildpack name (e.g. my-buildpack)
    * an empty blank string to use built-in buildpacks (i.e. autodetection)
-* `command` - (Optional, String) A custom start command for the application. (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_v3_app` resource.
-* `environment` - (Optional, String) A custom build environment for the application. (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_v3_app` resource.
+* `command` - (Optional, String) A custom start command for the application. (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_app` resource.
+* `environment` - (Optional, String) A custom build environment for the application. (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_app` resource.
 * `source_code_path` - (Required) An uri or path to target a zip file. this can be in the form of unix path (`/my/path.zip`) or url path (`http://zip.com/my.zip`)
 * `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the path specified. The usual way to set this is `${base64sha256(file("file.zip"))}`,
 where "file.zip" is the local filename of the lambda function source archive.
@@ -70,7 +70,7 @@ resource "zipper_file" "fixture" {
   output_path = "path/to/gobis-server.zip"
 }
 
-resource "cloudfoundry_v3_app" "gobis-server" {
+resource "cloudfoundry_app" "gobis-server" {
     name = "gobis-server"
     source_code_path = zipper_file.fixture.output_path
     source_code_hash = zipper_file.fixture.output_sha

--- a/docs/resources/route_destination.md
+++ b/docs/resources/route_destination.md
@@ -1,12 +1,12 @@
 ---
 layout: "cloudfoundry"
-page_title: "Cloud Foundry: cloudfoundry_v3_route_destination"
+page_title: "Cloud Foundry: cloudfoundry_route_destination"
 sidebar_current: "docs-cf-resource-route-destination"
 description: |-
   Provides a Cloud Foundry Route Destination resource.
 ---
 
-# cloudfoundry_v3_route_destination
+# cloudfoundry_route_destination
 
 Provides the mapping between a `route` and `app` resource so that traffic
 is routed to the application process from the route.
@@ -17,24 +17,24 @@ The following example creates an application with a route and maps the route
 
 ```hcl
 
-data "cloudfoundry_v3_domain" "foo" {
+data "cloudfoundry_domain" "foo" {
   name = "apps.internal"
 }
 
-resource "cloudfoundry_v3_app" "foo" {
+resource "cloudfoundry_app" "foo" {
 	name = "foo-with-route"
 	# ...
 }
 
-resource "cloudfoundry_v3_route" "foo" {
-	domain_id = data.cloudfoundry_v3_domain.foo.id
+resource "cloudfoundry_route" "foo" {
+	domain_id = data.cloudfoundry_domain.foo.id
 	space_id = "xxxx"
 	host = "basic-test-route"
 }
 
-resource "cloudfoundry_v3_route_destination" "foo" {
-	route_id = cloudfoundry_v3_route.foo.id
-	app_id = cloudfoundry_v3_app.foo.id
+resource "cloudfoundry_route_destination" "foo" {
+	route_id = cloudfoundry_route.foo.id
+	app_id = cloudfoundry_app.foo.id
 }
 ```
 


### PR DESCRIPTION
we don't need the v3 suffix on resource names to diffientiate between
resources from different providers, we can explicitly pass the provider
to the resources if using two versions with conflicting names