### PR TITLE
add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ dist/
 /cloudfoundry/cfapi
 *.after
 /cf-hcl-migration/cf-hcl-migration
+.gopath/
 
 website/vendor
 /terraform-provider-cloudfoundry

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-TEST?=$$(go list ./... |grep -v 'vendor')
+TEST?=$$(go list ./... |grep -v 'vendor'|grep -v '.gopath')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=cloudfoundry

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    go = pkgs.go;
+    localOverridesPath = ./local.nix;
+    forDev = true;
+  } // argsOuter;
+in (with args; {
+
+  terraformProviderCloudfoundryV3Env = (pkgs.stdenv.mkDerivation rec {
+    name = "tf-cfv3-env";
+    shortName = "tfcfv3";
+    buildInputs = with pkgs; [ go ]
+      ++ stdenv.lib.optionals forDev [ gitFull cacert cloudfoundry-cli ruby ];
+
+    LD_LIBRARY_PATH = "${pkgs.stdenv.lib.makeLibraryPath buildInputs}";
+    LANG="en_GB.UTF-8";
+    GOPATH = (toString (./.)) + "/.gopath";
+
+    shellHook = ''
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
+
+      mkdir -p $GOPATH
+    '';
+  }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})


### PR DESCRIPTION
as a quick and reproducible way of supplying all development dependencies.

Tested on macos 10.14 & linux.