### PR TITLE
documentation: fix inaccuracies, remove references to features we don't yet support in this fork

### DIFF
--- a/cloudfoundryv3/resource_cf_app.go
+++ b/cloudfoundryv3/resource_cf_app.go
@@ -39,7 +39,7 @@ func resourceApp() *schema.Resource {
 			},
 
 			"type": {
-				Description:  "The lifecycle type of the application. There are two types (lifecycles) of cloudfoundry application builds, 'buildpack' and 'docker'. For buildpack source types, you must supply `source_code_path` to a zip of application source code. For the 'docker' source type, you must supply the `docker_image`.",
+				Description:  "The lifecycle type of the application. There are two types (lifecycles) of cloudfoundry application builds, 'buildpack' and 'docker'.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "buildpack",

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -39,12 +39,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the application.
 * `space_id` - (Required) The GUID of the associated Cloud Foundry space.
+* `type` - (Optional, String) The lifecycle type of the application. There are two types (lifecycles) of cloudfoundry application builds, 'buildpack' and 'docker'. Default is `buildpack`.
 * `instances` - (Optional, Number) The number of app instances that you want to start. Defaults to 1.
 * `memory_in_mb` - (Optional, Number) The memory limit for each application instance in megabytes. If not provided, value is computed and retreived from Cloud Foundry.
 * `disk_in_mb` - (Optional, Number) The disk space to be allocated for each application instance in megabytes. If not provided, default disk quota is retrieved from Cloud Foundry and assigned.
 * `command` - (Optional, String) A custom start command for the application's web process. This overrides the start command provided by the buildpack.
 * `health_check_type` - (Optional, String) One of `port`, `process` or `http`
 * `health_check_endpoint` - (Optional, String) defaults to "/" set to a path to your healthcheck (only valid for `http` type checks)
+* `health_check_timeout` - (Optional, Number) The timeout in seconds for the health check.
+* `strategy` - (Optional) The deployment method. Currently only `rolling` supported.
 * `environment` - (Optional, map of String to string) environment variables for your application processes.
 
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -52,4 +52,3 @@ The following arguments are supported:
 * `app_id` - (Required) The GUID of the associated Cloud Foundry application
 * `droplet_id` - (Required) The GUID of the application droplet to deploy.
 * `strategy` - (Required) The deployment method. Currently only `rolling` supported.
-

--- a/docs/resources/droplet.md
+++ b/docs/resources/droplet.md
@@ -43,156 +43,15 @@ resource "cloudfoundry_droplet" "basic" {
 The following arguments are supported:
 
 * `app_id` - (Required) The GUID of the associated Cloud Foundry application
+* `type` - (Optional, String) The lifecycle type of the source. Should match that set in the associated `cloudfoundry_app`. For `buildpack` source types, you must supply `source_code_path` to a zip of application source code. For the `docker` source type, you must supply the `docker_image`.
 * `stack` - (Optional) The GUID of the stack the application will be deployed to. Use the [`cloudfoundry_stack`](website/docs/d/stack.html.markdown) data resource to lookup the stack GUID to override Cloud Foundry default.
 * `buildpacks` - (Optional, list of strings) The buildpacks used to stage the application. There are multiple options to choose from:
    * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag)
    * an installed admin buildpack name (e.g. my-buildpack)
    * an empty blank string to use built-in buildpacks (i.e. autodetection)
-* `command` - (Optional, String) A custom start command for the application. (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_app` resource.
-* `environment` - (Optional, String) A custom build environment for the application. (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_app` resource.
+* `command` - (Optional, String) A custom start command for the application (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_app` resource).
+* `environment` - (Optional, String) A custom build environment for the application (this is only used to trigger rebuild/deployment - it should be set to the output attribute from the `cloudfoundry_app` resource).
 * `source_code_path` - (Required) An uri or path to target a zip file. this can be in the form of unix path (`/my/path.zip`) or url path (`http://zip.com/my.zip`)
 * `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the path specified. The usual way to set this is `${base64sha256(file("file.zip"))}`,
 where "file.zip" is the local filename of the lambda function source archive.
 * `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0
-
-~> **NOTE:** [terraform-provider-zipper](https://github.com/ArthurHlt/terraform-provider-zipper)
-can create zip file from `tar.gz`, `tar.bz2`, `folder location`, `git repo` locally or remotely and provide `source_code_hash`.
-
-Example Usage with zipper:
-
-```hcl
-provider "zipper" {
-  skip_ssl_validation = false
-}
-
-resource "zipper_file" "fixture" {
-  source = "https://github.com/orange-cloudfoundry/gobis-server.git#v1.7.3"
-  output_path = "path/to/gobis-server.zip"
-}
-
-resource "cloudfoundry_app" "gobis-server" {
-    name = "gobis-server"
-    source_code_path = zipper_file.fixture.output_path
-    source_code_hash = zipper_file.fixture.output_sha
-    buildpacks = ["go_buildpack"]
-}
-```
-
-### Application Deployment strategy (Blue-Green deploy)
-
-* `strategy` - (Required) Strategy to use for creating/updating application. Default to `none`.
-Following are supported:
-  * `none`:
-      * Alias: `standard`, `v2`
-      * Description: This is the default strategy, it will restage/create/restart app with interruption
-  * `blue-green`:
-    * Alias: `blue-green-v2`
-    * Description: It will restage and create app without interruption and rollback if an error occurred.
-
-### Service bindings
-
-* `service_binding` - (Optional, Array) Service instances to bind to the application.
-
-  - `service_instance` - (Required, String) The service instance GUID.
-  - `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding. Defaults to empty map.
-
-~> **NOTE:** Modifying this argument will cause the application to be restaged.
-~> **NOTE:** Resource only manages service binding previously set by resource.
-
-### Routing
-
-* `routes` - (Optional, Set) The routes to map to the application to control its ingress traffic. Each route mapping is represented by its `route` block which supports fields documented below.
-
-The `route` block supports:
-- `route` - (Required, String) The route id. Route can be defined using the `cloudfoundry_route` resource
-- ~`port` - (Number) The port of the application to map the tcp route to.~
-
-~> **NOTE:** in the future, the `route` block will support the `port` attribute illustrated above to allow mapping of tcp routes, and listening on custom or multiple ports.
-~> **NOTE:** Route mappings can be controlled from either the `cloudfoundry_app.routes` or the `cloudfoundry_routes.target` attributes. Using both syntaxes will cause conflicts and result in unpredictable behavior.
-~> **NOTE:** A given route can not currently be mapped to more than one application using the `cloudfoundry_app.routes` syntax. As an alternative, use the `cloudfoundry_route.target` syntax instead in this specific use-case.
-~> **NOTE:** Resource only manages route mapping previously set by resource.
-
-#### Example usage:
-
-```hcl
-resource "cloudfoundry_app" "java-spring" {
-# [...]
- routes = [
-    { route = cloudfoundry_route.java-spring.id },
-    { route = cloudfoundry_route.java-spring-2.id }
-  ]
-}
-```
-
-### Environment Variables
-
-* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env).
-
-~> **NOTE:** Modifying this argument will cause the application to be restaged.
-
-### Health Checks
-
-* `health_check_http_endpoint` -(Optional, String) The endpoint for the http health check type. The default is '/'.
-* `health_check_type` - (Optional, String) The health check type which can be one of "`port`", "`process`", "`http`" or "`none`". Default is "`port`".
-* `health_check_timeout` - (Optional, Number) The timeout in seconds for the health check.
-
-## Attributes Reference
-
-The following attributes are exported along with any defaults for the inputs attributes.
-
-* `id` - The GUID of the application
-* `id_bg` - The GUID of the application updated by resource when strategy is blue-green.
-This allow change a resource linked to app resource id to be updated when app will be recreated.
-
-## Timeouts
-
-* App instance startup timeout - see the `timeout` argument.
-* App staging timeout - 15 mins.
-* Service binding timeout - 5 mins.
-
-## Import
-
-The current App can be imported using the `app` GUID, e.g.
-
-```bash
-$ terraform import cloudfoundry_app.spring-music a-guid
-```
-
-## Update resource using blue green app id
-
-This is an example of usage of `id_bg` attribute to update your resource on a changing app id by blue-green:
-
-```hcl
-resource "cloudfoundry_app" "test-app-bg" {
-    space            = "apaceid"
-    buildpack        = "abuildpack"
-    name             = "test-app-bg"
-    path             = "myapp.zip"
-    strategy         = "blue-green-v2"
-    routes {
-      route = "arouteid"
-    }
-}
-
-resource "cloudfoundry_app" "test-app-bg2" {
-  space            = "apaceid"
-  buildpack        = "abuildpack"
-  name             = "test-app-bg2"
-  path             = "myapp.zip"
-  strategy         = "blue-green-v2"
-  routes {
-    route = "arouteid"
-  }
-}
-
-resource "cloudfoundry_network_policy" "my-policy" {
-  policy {
-    destination_app = cloudfoundry_app.test-app-bg2.id_bg
-    port            = "8080"
-    protocol        = "tcp"
-    source_app      = cloudfoundry_app.test-app-bg.id_bg
-  }
-}
-
-# When you change either test-app-bg or test-app-bg2 this will affect my-policy to be updated because it use `id_bg` instead of id
-```

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -16,9 +16,9 @@ The following example creates an route for an application.
 
 ```hcl
 resource "cloudfoundry_route" "default" {
-    domain = data.cloudfoundry_domain.apps.domain.id
-    space = data.cloudfoundry_space.dev.id
-    hostname = "myapp"
+    domain_id = data.cloudfoundry_domain.apps.domain.id
+    space_id = data.cloudfoundry_space.dev.id
+    host = "myapp"
 }
 ```
 
@@ -26,17 +26,9 @@ resource "cloudfoundry_route" "default" {
 
 The following arguments are supported:
 
-- `domain` - (Required, String) The ID of the domain to map the host name to. If not provided the default application domain will be used.
-- `space` - (Required, String) The ID of the space to create the route in.
-- `hostname` - (Required, Optional) The application's host name. This is required for shared domains.
-
-The following arguments apply only to TCP routes.
-
-- `port` - (Optional, Int) The port to associate with the route for a TCP route. Conflicts with `random_port`.
-- `random_port` - (Optional, Bool) Set to 'true' to create a random port. Conflicts with `port` and defaults to false.
-
-The following argument applies only to HTTP routes.
-
+- `domain_id` - (Required, String) The ID of the domain to map the host name to. If not provided the default application domain will be used.
+- `space_id` - (Required, String) The ID of the space to create the route in.
+- `host` - (Required, Optional) The application's host name. This is required for shared domains.
 - `path` - (Optional) A path for a HTTP route.
 
 The following maps the route to an application.

--- a/docs/resources/route_destination.md
+++ b/docs/resources/route_destination.md
@@ -44,12 +44,9 @@ The following arguments are supported:
 
 * `app_id` - (Required) The GUID of the associated Cloud Foundry application.
 * `route_id` - (Required) The GUID of the associated Cloud Foundry route.
-* `process_type` - (Optional) The name of the process type within the application to route to. (default: `web`)
-
 
 ## Attributes Reference
 
 The following attributes are exported along with any defaults for the inputs attributes.
 
 * `id` - The GUID of the application
-

--- a/docs/resources/service_instance.md
+++ b/docs/resources/service_instance.md
@@ -21,8 +21,8 @@ data "cloudfoundry_service" "redis" {
 
 resource "cloudfoundry_service_instance" "redis1" {
   name = "pricing-grid"
-  space = cloudfoundry_space.dev.id
-  service_plan = data.cloudfoundry_service.redis.service_plans["shared-vm"]
+  space_id = cloudfoundry_space.dev.id
+  service_plan_id = data.cloudfoundry_service.redis.service_plans["shared-vm"]
 }
 ```
 
@@ -31,11 +31,10 @@ resource "cloudfoundry_service_instance" "redis1" {
 The following arguments are supported:
 
 * `name` - (Required, String) The name of the Service Instance in Cloud Foundry
-* `service_plan` - (Required, String) The ID of the [service plan](/docs/providers/cloudfoundry/d/service.html)
-* `space` - (Required, String) The ID of the [space](/docs/providers/cloudfoundry/r/space.html)
-* `json_params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request. By default, no params are provided.
+* `service_plan_id` - (Required, String) The ID of the [service plan](/docs/providers/cloudfoundry/d/service.html)
+* `space_id` - (Required, String) The ID of the [space](/docs/providers/cloudfoundry/r/space.html)
+* `params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request. By default, no params are provided.
 * `tags` - (Optional, List) List of instance tags. Some services provide a list of tags that Cloud Foundry delivers in [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES). By default, no tags are assigned.
-* `recursive_delete` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will delete any service bindings, service keys, and route mappings associated with the service instance. This flag should only be set when such dependent resources were provisioned outside of terraform, and need removal to enable deletion of the associated service instance.
 
 ## Attributes Reference
 


### PR DESCRIPTION
https://trello.com/c/OgjUw4xN

Fixes #12.

I'm not looking to rewrite the documentation here, just make it so it's no longer _incorrect_. Some remnants of the documentation from the parent project had been left in place where they shouldn't have been, leading to confusion.